### PR TITLE
we do our own deploys now

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -104,7 +104,7 @@ for (const l of changelog) {
 }
 
 const result = [
-	`# ${toTitleCase(packageName)} release-notes ${date}`,
+	`# ${toTitleCase(packageName)} #release-notes ${date}`,
 	'',
 	`The ${moduleName} has been updated from ${oldVersion} to ${newVersion}`,
 	'',

--- a/src/index.js
+++ b/src/index.js
@@ -104,13 +104,6 @@ for (const l of changelog) {
 }
 
 const result = [
-	'================================ Deploy request ================================',
-	'',
-	`#devops please deploy #${packageName} ${newVersion} to production`,
-	'@@devops',
-	'',
-	'================================ Release notes =================================',
-	'```',
 	`# ${toTitleCase(packageName)} release-notes ${date}`,
 	'',
 	`The ${moduleName} has been updated from ${oldVersion} to ${newVersion}`,
@@ -120,8 +113,6 @@ const result = [
 	...notableChanges,
 	'',
 	...changelog,
-	'```',
-	'================================================================================',
 ];
 
 console.log(result.join('\n'));

--- a/src/index.js
+++ b/src/index.js
@@ -109,10 +109,13 @@ const result = [
 	`The ${moduleName} has been updated from ${oldVersion} to ${newVersion}`,
 	'',
 	'Notable changes',
-	'* <only keep the important and rephrase>',
+	'* [only keep the important and rephrase]',
 	...notableChanges,
 	'',
+	'<details><summary>Expand changelog</summary>',
+	'',
 	...changelog,
+	'</details>',
 ];
 
 console.log(result.join('\n'));


### PR DESCRIPTION
.. I propose the following:

* Flowzone/Renovate will add release notes as PR comments. (PR pending)
* whoever merges the PR has the responsibility to edit the comment and re-phrase the bullet point list as required
* this PR removes the superfluous "devops please ..." and sets the tool to be used programatically in a CI pipeline

Related: https://github.com/product-os/flowzone/pull/957